### PR TITLE
Improved Flowdock threading

### DIFF
--- a/FlowdockNotify.php
+++ b/FlowdockNotify.php
@@ -71,7 +71,7 @@ function flowdock_make_request($article, $user, $summary, $method)
 function flowdock_notify_revise($article, $user, $content, $summary,
     $isMinor, $isWatch, $section, $flags, $revision, $status, $baseRevId)
 {
-    $method = ($revision) ? 'created' : 'revised';
+    $method = $status->value['new'] ? 'created' : 'revised';
     flowdock_make_request($article, $user, $summary, $method);
     return true;
 }

--- a/FlowdockNotify.php
+++ b/FlowdockNotify.php
@@ -44,6 +44,7 @@ function flowdock_make_request($article, $user, $summary, $method)
         'event' => 'activity',
         'author' => array(
             'name' => $user->mRealName,
+            'email' => $user->mEmail,
             'avatar' => sprintf("https://www.gravatar.com/avatar/%s?s=50", md5(strtolower($user->mEmail))),
         ),
         'title' => sprintf("%s has been %s", $article->getTitle()->mTextform, $method),

--- a/FlowdockNotify.php
+++ b/FlowdockNotify.php
@@ -35,7 +35,7 @@ curl -i -X POST -H "Content-Type: application/json" -d '{
 }' https://api.flowdock.com/messages
 */
 
-function flowdock_make_request($article, $user, $summary, $method)
+function flowdock_make_request($article, $user, $summary, $content, $method)
 {
     global $flowdock_token, $wgCanonicalServer;
 
@@ -47,11 +47,12 @@ function flowdock_make_request($article, $user, $summary, $method)
             'email' => $user->mEmail,
             'avatar' => sprintf("https://www.gravatar.com/avatar/%s?s=50", md5(strtolower($user->mEmail))),
         ),
+        'body' => $summary,
         'title' => sprintf("%s has been %s", $article->getTitle()->mTextform, $method),
         'external_thread_id' => (string)$article->getId(),
         'thread' => array(
             'title' => $article->getTitle()->mTextform,
-            'body' => $summary,
+            'body' => $content->getParserOutput($article->getTitle())->getText(),
             'external_url' => sprintf("%s/%s", $wgCanonicalServer, $article->getTitle()->mUrlform),
         )
     );
@@ -73,13 +74,13 @@ function flowdock_notify_revise($article, $user, $content, $summary,
     $isMinor, $isWatch, $section, $flags, $revision, $status, $baseRevId)
 {
     $method = $status->value['new'] ? 'created' : 'revised';
-    flowdock_make_request($article, $user, $summary, $method);
+    flowdock_make_request($article, $user, $summary, $content, $method);
     return true;
 }
 
 function flowdock_notify_delete($article, $user, $reason, $id, $content, $logEntry)
 {
-    flowdock_make_request($article, $user, $reason, 'deleted');
+    flowdock_make_request($article, $user, $reason, $content, 'deleted');
     return true;
 }
 


### PR DESCRIPTION
Show the article content in the thread's main body and put the edit message into the activity's body.

Other improvements:
- Fix new article creation detection
- Add author's email address field

Resulting thread view:
![thread-view](https://cloud.githubusercontent.com/assets/888333/7563395/6a305dbc-f7e5-11e4-84b9-539eed1dfc54.png)

Inbox view:
![inbox-view](https://cloud.githubusercontent.com/assets/888333/7563396/7164a304-f7e5-11e4-8214-57a8c059bcdf.png)
